### PR TITLE
Fixed duplicate messages & channel switching bug in issue #65. Also fixed realtime message deletion for direct messages.

### DIFF
--- a/app/backend/api.py
+++ b/app/backend/api.py
@@ -8,17 +8,19 @@ from fastapi import FastAPI, Depends, Header, WebSocket, WebSocketDisconnect, HT
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
-from app.backend.database import SessionLocal, init_db  
+from app.backend.database import SessionLocal, init_db
 from app.backend.models import User, DirectMessage, Channel, ChannelMessage, UserChannel
 from app.backend.schemas import ChannelResponse, UserCreate, DirectMessageCreate, ChannelCreate, ChannelMessageCreate
+
 
 # Initialize FastAPI
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     init_db()
-    yield  
+    yield
 
-app = FastAPI(lifespan=lifespan) 
+
+app = FastAPI(lifespan=lifespan)
 active_connections = {}
 router = APIRouter()
 
@@ -31,12 +33,14 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 def get_db():
     db = SessionLocal()
     try:
         yield db
     finally:
         db.close()
+
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from typing import List
@@ -45,45 +49,48 @@ from app.backend.models import ChannelMessage
 
 channel_connections = {}
 
+
 @app.websocket("/ws/channel/{channel_id}")
 async def websocket_endpoint(websocket: WebSocket, channel_id: int, db: Session = Depends(get_db)):
     await websocket.accept()
     if channel_id not in channel_connections:
         channel_connections[channel_id] = []
     channel_connections[channel_id].append(websocket)
-    print(f"Client connected to channel {channel_id}")
+    print(f"✅ Client connected to channel {channel_id}")
 
     try:
         while True:
-            data = await websocket.receive_json()  # Receive message as JSON
-            sender_id = data.get("sender_id")  # Extract sender ID
+            data = await websocket.receive_json()
+            sender_id = data.get("sender_id")
             message_text = data.get("text")
+
             if not sender_id or not message_text:
                 continue
+
             print(f"Message in channel {channel_id}: {data}")
-            
-            #  Save message to the database
+
             message = ChannelMessage(
                 channel_id=channel_id,
-                sender_id=sender_id,  # Change this to the actual sender's ID (pass it from frontend)
+                sender_id=sender_id,
                 text=message_text
             )
             db.add(message)
             db.commit()
+            db.refresh(message)
+
+            response_data = {
+                "id": message.id,
+                "channel_id": channel_id,
+                "sender_id": sender_id,
+                "text": message_text
+            }
 
             for ws in channel_connections[channel_id]:
-                await ws.send_json({"sender_id": sender_id, "text": message_text})
-            if sender_id in active_connections:
-                for ws in active_connections[sender_id]:
-                    try:
-                        await ws.send_json(data)
+                await ws.send_json(response_data)
 
-                    except Exception as e:
-                        print(f"Failed to send message to {sender_id}: {e}")
     except WebSocketDisconnect:
         print(f"Client disconnected from channel {channel_id}")
         channel_connections[channel_id].remove(websocket)
-
 
 
 @app.post("/test/channel-message/")
@@ -102,7 +109,7 @@ def test_channel_message(channel_id: int, sender_id: int, text: str, db: Session
 @app.post("/login")
 def login(user: UserCreate, db: Session = Depends(get_db)):
     """Handles login requests and authenticates users."""
-    
+
     # Convert username to lowercase before checking in the database
     existing_user = db.query(User).filter(User.username.ilike(user.username)).first()
 
@@ -115,6 +122,7 @@ def login(user: UserCreate, db: Session = Depends(get_db)):
         raise HTTPException(status_code=401, detail="Incorrect password")
 
     return {"id": existing_user.id, "username": existing_user.username, "is_admin": existing_user.is_admin}
+
 
 @app.websocket("/realtime/direct/{user_id}")
 async def websocket_endpoint(websocket: WebSocket, user_id: int, db: Session = Depends(get_db)):
@@ -175,10 +183,11 @@ async def websocket_endpoint(websocket: WebSocket, user_id: int, db: Session = D
     except Exception as e:
         print(f"[ERROR] WebSocket crashed: {e}")
 
+
 # webSocket for Channels
 @app.websocket("/realtime/channel/{channel_id}/{user_id}")
 async def websocket_channel_endpoint(
-    websocket: WebSocket, channel_id: int, user_id: int, db: Session = Depends(get_db)
+        websocket: WebSocket, channel_id: int, user_id: int, db: Session = Depends(get_db)
 ):
     """Handles real-time channel messaging."""
     user = db.query(User).filter_by(id=user_id).first()
@@ -222,14 +231,16 @@ async def websocket_channel_endpoint(
 
     except WebSocketDisconnect:
         active_connections[channel_id].remove(websocket)
-        if not active_connections[channel_id]:  
+        if not active_connections[channel_id]:
             del active_connections[channel_id]
+
 
 # retrieve Users
 @app.get("/users/")
 def get_users(db: Session = Depends(get_db)):
     users = db.query(User).all()
     return [{"id": user.id, "name": user.username} for user in users]
+
 
 # store Direct Messages
 def store_direct_message(db: Session, sender_id: int, receiver_id: int, text: str):
@@ -249,8 +260,9 @@ def store_direct_message(db: Session, sender_id: int, receiver_id: int, text: st
         "sender_id": sender_id,
         "receiver_id": receiver_id,
         "text": new_message.text,
-        "timestamp": new_message.timestamp  
+        "timestamp": new_message.timestamp
     }
+
 
 def store_channel_message(db: Session, sender_id: int, channel_id: int, text: str):
     sender = db.query(User).filter(User.id == sender_id).first()
@@ -269,8 +281,9 @@ def store_channel_message(db: Session, sender_id: int, channel_id: int, text: st
         "sender_id": sender_id,
         "channel_id": channel_id,
         "text": new_message.text,
-        "timestamp": new_message.timestamp  
+        "timestamp": new_message.timestamp
     }
+
 
 # get Messages Between Users
 @app.get("/messages/{user1_id}/{user2_id}")
@@ -300,6 +313,7 @@ def get_messages(user1_id: int, user2_id: int, db: Session = Depends(get_db)):
         for msg in messages
     ]
 
+
 # get Channel Messages
 @app.get("/channel-messages/{channel_id}")
 def get_channel_messages(channel_id: int, db: Session = Depends(get_db)):
@@ -311,7 +325,9 @@ def get_channel_messages(channel_id: int, db: Session = Depends(get_db)):
     )
     return [{"id": msg.id, "sender_id": msg.sender_id, "text": msg.text} for msg in messages]
 
+
 global_channel_connections: Set[WebSocket] = set()
+
 
 @app.websocket("/realtime/global/channels")
 async def websocket_global_channels(websocket: WebSocket, db: Session = Depends(get_db)):
@@ -327,6 +343,7 @@ async def websocket_global_channels(websocket: WebSocket, db: Session = Depends(
         print(f"WebSocket error: {e}")
         global_channel_connections.remove(websocket)
 
+
 # Function to broadcast global channel updates
 async def broadcast_channel_update(message: str):
     for connection in global_channel_connections:
@@ -336,14 +353,16 @@ async def broadcast_channel_update(message: str):
             print(f"Failed to send message to connection: {e}")
             global_channel_connections.remove(connection)
 
+
 # create Channel
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
+
 @app.post("/channels/")
 async def create_channel(channel: ChannelCreate, db: Session = Depends(get_db), user_id: int = Header(None)):
     logger.debug(f"Received request to create channel. User ID: {user_id}")
-    
+
     try:
         # checks if channel name is blank
         channel_name = channel.name.strip()
@@ -360,7 +379,7 @@ async def create_channel(channel: ChannelCreate, db: Session = Depends(get_db), 
         if not current_user:
             logger.error(f"User not found: {user_id}")
             raise HTTPException(status_code=404, detail="User not found")
-        
+
         if not current_user.is_admin:
             logger.error(f"User is not an admin: {user_id}")
             raise HTTPException(status_code=403, detail="Only admins can create channels")
@@ -381,12 +400,13 @@ async def create_channel(channel: ChannelCreate, db: Session = Depends(get_db), 
         }))
 
         return new_channel
-    
+
     except HTTPException as e:
         raise e
     except Exception as e:
         logger.error(f"Error creating channel: {str(e)}")
         raise HTTPException(status_code=500, detail="Internal server error")
+
 
 # delete channel
 @app.delete("/delete_channel/{channel_id}")
@@ -432,8 +452,10 @@ def join_channel(channel_id: int, user_id: int, db=Depends(get_db)):
     new_membership = UserChannel(user_id=user.id, channel_id=channel_id)
     db.add(new_membership)
     db.commit()
-    
+
     return {"message": "Successfully joined the channel"}
+
+
 @app.get("/channels/", response_model=list[ChannelResponse])
 def get_channels(user_id: int = Header(None), db: Session = Depends(get_db)):
     """Retrieve all available channels, including public channels and private channels the user is part of."""
@@ -458,9 +480,9 @@ def get_channels(user_id: int = Header(None), db: Session = Depends(get_db)):
 
 @app.delete("/channel-messages/{message_id}")
 async def delete_channel_message(
-    message_id: int, 
-    db: Session = Depends(get_db), 
-    user_id: int = Header(None)
+        message_id: int,
+        db: Session = Depends(get_db),
+        user_id: int = Header(None)
 ):
     # Check if admin
     current_user = db.query(User).filter(User.id == user_id).first()
@@ -482,6 +504,7 @@ async def delete_channel_message(
 
     return {"message": "Message deleted successfully"}
 
+
 async def notify_message_deleted(channel_id: int, message_id: int):
     if channel_id in active_connections:
         for websocket in active_connections[channel_id]:
@@ -494,11 +517,12 @@ async def notify_message_deleted(channel_id: int, message_id: int):
             except Exception as e:
                 print(f"Failed to notify client: {e}")
 
+
 @app.delete("/direct-messages/{message_id}")
 async def delete_direct_message(
-    message_id: int, 
-    db: Session = Depends(get_db), 
-    user_id: int = Header(None)
+        message_id: int,
+        db: Session = Depends(get_db),
+        user_id: int = Header(None)
 ):
     # Check if admin
     current_user = db.query(User).filter(User.id == user_id).first()

--- a/app/frontend/components/ChatBox.vue
+++ b/app/frontend/components/ChatBox.vue
@@ -44,14 +44,16 @@
 
       const messageStore = reactive(useDirectMessageStore());
       const messages = computed(() => {
+        let list = [];
+
         if (props.selectedUser) {
-          console.log("Direct messages:", messageStore.messages[props.selectedUser.id] || []);
-          return messageStore.messages[props.selectedUser.id] || [];
+          list = messageStore.messages[props.selectedUser.id] || [];
         } else if (props.selectedChannel) {
-          console.log("Channel messages:", messageStore.messages[props.selectedChannel.id] || []); // Log channel messages
-          return messageStore.messages[props.selectedChannel.id] || [];
+          list = messageStore.messages[props.selectedChannel.id] || [];
         }
-        return [];
+
+        // Filter out messages that have been deleted.
+        return list.filter(msg => msg?.senderId && msg?.content);
       });
 
 
@@ -221,8 +223,15 @@
               return props.selectedUser?.name || "Loading...";
           }
 
+
+        //   console.log("userMap:", userMap);
+        // console.log("senderId:", message.senderId);
+        // console.log("userMap.value[senderId]:", userMap.value[message.senderId]);
+
+
+        
           // For channel messages, look up the sender's name in userMap
-          return userMap.value[message.senderId] || "Loading...";
+          return userMap.value[Number(message.senderId)] || "Loading...";
       }
 
 

--- a/app/frontend/components/ChatBox.vue
+++ b/app/frontend/components/ChatBox.vue
@@ -126,12 +126,6 @@
               userId.value,
               "direct"
             );
-
-            if (!messageStore.messages[props.selectedUser.id]) {
-              messageStore.messages[props.selectedUser.id] = [];
-            }
-
-            messageStore.messages[props.selectedUser.id].push(messageData);
           }
           
           if (props.selectedChannel) {
@@ -171,12 +165,13 @@
         }
 
 
-
-
-
-
       // Delete a message
       async function deleteMessage(messageId) {
+        if (!messageId) {
+          console.warn("Tried to delete a message without an ID.");
+          return;
+        }
+
         try {
           // Determine if it's a direct message or a channel message
           const url = props.selectedUser

--- a/app/frontend/components/ChatBox.vue
+++ b/app/frontend/components/ChatBox.vue
@@ -52,8 +52,7 @@
           list = messageStore.messages[props.selectedChannel.id] || [];
         }
 
-        // Filter out messages that have been deleted.
-        return list.filter(msg => msg?.senderId && msg?.content);
+        return list;
       });
 
 
@@ -252,16 +251,12 @@
         }
       });
 
-
-    watch(() => props.selectedChannel, (newChannel) => {
-        if (newChannel) {
-            console.log(`Switched to channel: ${newChannel.id}`);
-            fetchMessages(newChannel.id, "channel");
-        }
-    });
-
-
-
+      watch(() => props.selectedChannel, (newChannel) => {
+          if (newChannel) {
+              console.log(`Switched to channel: ${newChannel.id}`);
+              fetchMessages(newChannel.id, "channel");
+          }
+      });
 
       watch(messages, (newMessages) => {
           scrollToBottom();

--- a/app/frontend/services/websocketService.js
+++ b/app/frontend/services/websocketService.js
@@ -28,10 +28,19 @@ export function connectWebSocket(userId) {
         const message = JSON.parse(event.data);
 
         if (message.action === "message_deleted") {
-          messageStore.deleteMessage(
-            message.receiver_id || message.sender_id,
-            message.message_id
-          );
+
+          if (message.type === "direct") {
+            const currentUserId = Number(localStorage.getItem("userId"));
+            const conversationId = (message.receiver_id === currentUserId)
+              ? message.sender_id
+              : message.receiver_id;
+        
+            messageStore.deleteMessage(message.message_id, conversationId);
+          }
+
+          if (message.type === "channel" && Number(message.channel_id)) {
+            messageStore.deleteMessage(message.message_id, message.channel_id);
+          }
           return;
         }
 

--- a/app/frontend/store/directMessageStore.js
+++ b/app/frontend/store/directMessageStore.js
@@ -32,12 +32,22 @@ export const useDirectMessageStore = defineStore("directMessage", {
             this.messages[receiverId].push(message);
         },
         receiveMessage(message) {
-            if (!this.messages[message.sender_id]) {
-                this.messages[message.sender_id] = [];
-            }
+            const convId = message.sender_id === Number(localStorage.getItem("userId"))
+                ? message.receiver_id
+                : message.sender_id;
 
-            this.messages[message.sender_id].push(message);
-        },
+            if (!this.messages[convId]) {
+                this.messages[convId] = [];
+            }
+            
+            this.messages[convId].push({
+                id: message.id,
+                senderId: message.sender_id,
+                receiverId: message.receiver_id,
+                content: message.content,
+                timestamp: message.timestamp,
+            });
+        },          
         receiveChannelMessage(message) {
             const channelId = message.channel_id;
             if (!this.messages[channelId]) {
@@ -51,11 +61,12 @@ export const useDirectMessageStore = defineStore("directMessage", {
                 timestamp: message.timestamp,
               });
         },
-        subscribeToDirectMessages() {
-            onDirectMessage((message) => {
-                const { receiver_id, text } = message;
-                this.addMessage(receiver_id, {text, received: true})
-            })
+        deleteMessage(messageId, conversationId) {
+            if (!this.messages[conversationId]) return;
+            const index = this.messages[conversationId].findIndex(m => m.id === messageId);
+            if (index !== -1) {
+              this.messages[conversationId].splice(index, 1);
+            }
         }
     },
 });

--- a/app/frontend/store/directMessageStore.js
+++ b/app/frontend/store/directMessageStore.js
@@ -43,7 +43,13 @@ export const useDirectMessageStore = defineStore("directMessage", {
             if (!this.messages[channelId]) {
                 this.messages[channelId] = [];
             }
-            this.messages[channelId].push(message);
+
+            this.messages[channelId].push({
+                id: message.id,
+                senderId: message.sender_id,
+                content: message.text,
+                timestamp: message.timestamp,
+              });
         },
         subscribeToDirectMessages() {
             onDirectMessage((message) => {

--- a/app/frontend/store/directMessageStore.js
+++ b/app/frontend/store/directMessageStore.js
@@ -38,6 +38,13 @@ export const useDirectMessageStore = defineStore("directMessage", {
 
             this.messages[message.sender_id].push(message);
         },
+        receiveChannelMessage(message) {
+            const channelId = message.channel_id;
+            if (!this.messages[channelId]) {
+                this.messages[channelId] = [];
+            }
+            this.messages[channelId].push(message);
+        },
         subscribeToDirectMessages() {
             onDirectMessage((message) => {
                 const { receiver_id, text } = message;


### PR DESCRIPTION
Duplicate message bug cause:

* When onmounted was called on the frontend, another websocket connection was created, causing the event listeners to be added again.

We could reproduce this by logging in as a user, logging out and then logging back in with a different user. Since the chatbox had to be destroyed when logging out, it is recreated with onmounted being called again, leading to too many event listeners for messages and thus duplicate messaages.

The fix: Make sure listeners are only ever added once.

Channel switching bug was fixed by migrating to a single websocket instead of separate websockets for channels and direct messgaes.