### PR TITLE
Post images in chat. Backend and frontend. Issues #49, #50 and #51

### DIFF
--- a/app/backend/api.py
+++ b/app/backend/api.py
@@ -691,7 +691,6 @@ async def upload_image(file: UploadFile = File(...), uploader_id: int = Form(...
 
     return {"filename": file_id}
 
-
 def generate_media_id(length=6):
     alphabet = string.ascii_letters + string.digits
     return ''.join(secrets.choice(alphabet) for _ in range(length))

--- a/app/backend/api.py
+++ b/app/backend/api.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 from PIL import Image
 from fastapi import FastAPI, Depends, Header, WebSocket, WebSocketDisconnect, HTTPException, UploadFile, File
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy.orm import Session
 from app.backend.database import SessionLocal, init_db, get_db
@@ -644,3 +644,26 @@ async def upload_video(file: UploadFile = File(...)):
         return {"filename": file_id}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error uploading video: {str(e)}")
+    
+@app.get("/media/images/{file_id}")
+async def get_image(file_id: str):
+    file_path = os.path.join(image_dir, file_id)
+    
+    if not os.path.exists(file_path):
+        raise HTTPException(status_code=404, detail="Image not found")
+    
+    return FileResponse(
+        file_path,
+        headers={
+            "Cache-Control": "public, max-age=86400"  # 24hr cache
+        }
+    )
+
+@app.get("/media/videos/{file_id}")
+async def get_video(file_id: str):
+    file_path = os.path.join(video_dir, file_id)
+    
+    if not os.path.exists(file_path):
+        raise HTTPException(status_code=404, detail="Video not found")
+    
+    return FileResponse(file_path, media_type="video/mp4")

--- a/app/backend/api.py
+++ b/app/backend/api.py
@@ -16,7 +16,7 @@ from app.backend.models import User, DirectMessage, Channel, ChannelMessage, Use
 from app.backend.schemas import ChannelResponse, UserCreate, DirectMessageCreate, ChannelCreate, ChannelMessageCreate
 from typing import List
 
-image_dir = os.path.join(os.path.dirname(__file__), "media", "images")
+image_dir = "./app/backend/media/images"
 os.makedirs(image_dir, exist_ok=True)
 
 # Initialize FastAPI
@@ -28,7 +28,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 app.mount(
     "/media/images",
-    StaticFiles(directory=os.path.join(os.path.dirname(__file__), "media", "images")),
+    StaticFiles(directory="./app/backend/media/images"),
     name="images"
 )
 active_connections = {}

--- a/app/backend/models.py
+++ b/app/backend/models.py
@@ -81,3 +81,21 @@ class UserChannel(Base):
     # relationships to user and channel
     user = relationship("User", back_populates="channels")
     channel = relationship("Channel", back_populates="users")
+
+class Image(Base):
+    __tablename__ = "images"
+
+    id = Column(Integer, primary_key=True, index=True)
+    filename = Column(String, unique=True, index=True)
+    uploader_id = Column(Integer)
+    width = Column(Integer)
+    height = Column(Integer)
+
+class Video(Base):
+    __tablename__ = "videos"
+
+    id = Column(Integer, primary_key=True, index=True)
+    filename = Column(String, unique=True, index=True)
+    uploader_id = Column(Integer)
+    width = Column(Integer)
+    height = Column(Integer)

--- a/app/frontend/components/ChatBox.vue
+++ b/app/frontend/components/ChatBox.vue
@@ -22,7 +22,7 @@
               controls
               class="chat-video"
             >
-              <source :src="getVideoUrl(msg.content)" type="video/mp4">
+              <source :src="getVideoUrl(msg.content)" :type="getVideoMimeType(msg.content)">
               Your browser does not support the video tag.
             </video>
           </div>
@@ -238,6 +238,10 @@
       function getImageUrl(content) {
 		// Extract the filename from the image tag
         const filename = content.slice(7, -1);
+        if (!isValidFilename(filename)) {
+          console.error("Invalid image filename");
+          return "";
+        }
         return `http://localhost:8000/media/images/${filename}`;
       }
 
@@ -251,7 +255,30 @@
 
       function getVideoUrl(content) {
         const filename = content.slice(7, -1);
+        if (!isValidFilename(filename)) {
+          console.error("Invalid video filename");
+          return "";
+        }
         return `http://localhost:8000/media/videos/${filename}`;
+      }
+
+
+      function getVideoMimeType(content) {
+        const filename = content.slice(7, -1);
+        const extension = filename.split('.').pop().toLowerCase();
+        return {
+          'mp4': 'video/mp4',
+          'webm': 'video/webm',
+          'mov': 'video/quicktime'
+        }[extension] || 'video/mp4'; // Default fallback
+      }
+
+      function isValidFilename(filename) {
+        const validExtensions = ['png', 'jpg', 'jpeg', 'gif', 'mp4', 'webm', 'mov'];
+        const extension = filename.split('.').pop().toLowerCase();
+        return validExtensions.includes(extension) && 
+              !filename.includes('/') && 
+              !filename.includes('..');
       }
 
       async function uploadVideo(file) {
@@ -385,6 +412,7 @@
         isVideoMessage,
         getVideoUrl,
         uploadVideo,
+        getVideoMimeType,
       };
     },
   };

--- a/app/frontend/components/ChatBox.vue
+++ b/app/frontend/components/ChatBox.vue
@@ -16,6 +16,7 @@
   
       <!-- ✅ FIXED: Ensure message input shows when a user or channel is selected -->
       <div class="message-input" v-if="selectedUser || selectedChannel">
+        <button class = "insertFileButton" @click="insertFile" >+</button>
         <input v-model="newMessage" @keyup.enter="sendMessage" placeholder="Type a message..." />
         <button @click="sendMessage" :disabled="!newMessage.trim()">Send</button>
       </div>
@@ -202,6 +203,44 @@
         });
       }
 
+      function insertFile() {
+        const fileInput = document.createElement("input");
+        fileInput.type = "file";
+        fileInput.style.display = "none";
+      
+        // listen for file inputs
+        fileInput.addEventListener("change", async (event) => {
+          const selectedFile = event.target.files[0];
+          if (selectedFile) {
+            console.log("Selected file:", selectedFile);
+      
+            // create an object (form data) 
+            const formData = new FormData();
+            formData.append("file", selectedFile);
+      
+            try {
+              // send the form data object via an axios.post request
+              const response = await axios.post("http://localhost:8000/upload", formData, {
+                headers: {
+                  "Content-Type": "multipart/form-data",
+                },
+              });
+      
+              console.log("File uploaded successfully:", response.data);
+            } catch (error) {
+              console.error("Error uploading file:", error);
+            }
+          }
+        });
+      
+        // this will open the file explorer when clicking on the button
+        document.body.appendChild(fileInput);
+        fileInput.click();
+      
+        // Remove the input once done using it
+        fileInput.remove();
+      }
+
       watch(() => props.selectedUser, (newUser) => {
         if (newUser) {
           console.log(`Switched to user: ${newUser.id}`);
@@ -261,7 +300,9 @@
         receiveChannelMessage,
         getOtherUsername,
         scrollToBottom,
+        insertFile,
       };
+      
     },
   };
   </script>
@@ -373,6 +414,13 @@
 
     .trash-button:hover {
       color: #a30000;
+    }
+
+    .insertFileButton{
+      font-size : 100px;
+      background: none;
+      padding-right : 10px;
+      margin-right : 10px;
     }
 
 </style>

--- a/app/frontend/components/ChatBox.vue
+++ b/app/frontend/components/ChatBox.vue
@@ -295,6 +295,7 @@
             let fileTag;
             const formData = new FormData();
             formData.append("file", selectedFile);
+            formData.append("uploader_id", localStorage.getItem("userId"));
 
             if (selectedFile.type.startsWith("image/")) {
               // Handle image upload


### PR DESCRIPTION
Images are saved to a /media/images/ folder located alongside database.db.

Each uploaded image is converted to PNG and given a UUID-based filename

Metadata for each image is stored in the database:

filename
width
height
uploader_id
uuid
Messaging Flow

User selects an image (via the "+" button).
The image is uploaded and saved on the server.
A [IMAGE:filename.png] tag is inserted into the chat input field.
When the message is sent, it is handled like any normal text message.
The frontend detects the [IMAGE:...] tag and renders the corresponding image using the stored filename.